### PR TITLE
Update StorageFactory.sol

### DIFF
--- a/StorageFactory.sol
+++ b/StorageFactory.sol
@@ -16,10 +16,10 @@ contract StorageFactory is SimpleStorage {
     function sfStore(uint256 _simpleStorageIndex, uint256 _simpleStorageNumber) public {
         // Address 
         // ABI 
-        SimpleStorage(address(simpleStorageArray[_simpleStorageIndex])).store(_simpleStorageNumber);
+        simpleStorageArray[_simpleStorageIndex].store(_simpleStorageNumber);
     }
     
     function sfGet(uint256 _simpleStorageIndex) public view returns (uint256) {
-        return SimpleStorage(address(simpleStorageArray[_simpleStorageIndex])).retrieve();
+        return simpleStorageArray[_simpleStorageIndex].retrieve();
     }
 }


### PR DESCRIPTION
SimpleStorage objects can be directly accessed from given array, No need to explicitly cast in another object.